### PR TITLE
Support building on Ubuntu Focal

### DIFF
--- a/src/messaging/sock/networkasio.hpp
+++ b/src/messaging/sock/networkasio.hpp
@@ -25,7 +25,11 @@ namespace qi { namespace sock {
     using socket_option_no_delay_type = boost::asio::ip::tcp::no_delay;
     using accept_option_reuse_address_type = boost::asio::ip::tcp::acceptor::reuse_address;
     using error_code_type = boost::system::error_code;
+#if BOOST_VERSION >= 107000
+    using io_service_type = boost::asio::io_context;
+#else
     using io_service_type = boost::asio::io_service;
+#endif
     using const_buffer_type = boost::asio::const_buffer;
     static io_service_type& defaultIoService()
     {

--- a/src/messaging/sock/socketwithcontext.hpp
+++ b/src/messaging/sock/socketwithcontext.hpp
@@ -37,7 +37,11 @@ namespace qi { namespace sock {
 
     io_service_t& get_io_service()
     {
-      return socket.get_io_service();
+      #if BOOST_VERSION >= 107000
+        return static_cast<io_service_t&>(socket.get_executor().context());
+      #else
+        return socket.get_io_service();
+      #endif
     }
 
     void set_verify_mode(decltype(N::sslVerifyNone()) x)


### PR DESCRIPTION
Due to changes in the networking API of Boost 1.70, libqi no longer compiles.

This PR fixes compilation by:
- Replacing calls to `get_io_service()` by `get_executor().context()`
- Keeping the calls to `get_io_service()` for the internal types of libqi (a better solution would be to upgrade libqi's API to follow the networking TS changes).

For details, see:
- https://www.boost.org/doc/libs/1_70_0/doc/html/boost_asio/history.html
- https://www.boost.org/doc/libs/1_70_0/doc/html/boost_asio/net_ts.html